### PR TITLE
Updated link to 'how to install'

### DIFF
--- a/_posts/2015-05-15-version-05.md
+++ b/_posts/2015-05-15-version-05.md
@@ -10,7 +10,7 @@ categories: news
 We are happy to announce the release of version 0.5 today. Functionality-wise, this version does not introduce anything new. However, we have made two major changes:
 
 - GeoKey 0.5 requires Postgres 9.4. The upgrade is necessary so we can use the very latest additions to Postgres, namely JSONB data type. We switch from hstore to JSONB because it allows to store, retrieve and update contributions more efficiently.
-- We simplified installing and updating GeoKey. You can now install and update [GeoKey via PyPI](https://pypi.python.org/pypi/geokey). Have a look at the updated [install instructions](http://localhost:4000/help/how-to-install.html).
+- We simplified installing and updating GeoKey. You can now install and update [GeoKey via PyPI](https://pypi.python.org/pypi/geokey). Have a look at the updated [install instructions](http://geokey.org.uk/help/how-to-install.html).
 
 ## Changes to the API
 


### PR DESCRIPTION
'localhost' was left in the url before and therefore the link did not work for the user
